### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,6 @@
 name: DBYN Deployment Pipeline
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/DBYN-DHABYAN/DBYN-MAIN/security/code-scanning/2](https://github.com/DBYN-DHABYAN/DBYN-MAIN/security/code-scanning/2)

To fix the issue, we should add a `permissions` block to the workflow. The best practice is to set this block at the root level (top of the YAML) so it applies to all jobs unless overridden locally. Based on CodeQL's recommendation and the analysis above, `contents: read` is the minimal starting point and is sufficient for the workflow's operations (checking out code and reading files). No steps require write access to repository contents. The only change required is to add a `permissions` block just below the `name` statement near the top of the `.github/workflows/deploy.yml` file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
